### PR TITLE
Bench Structlinq

### DIFF
--- a/Benchmark/Cistern.Benchmarks.csproj
+++ b/Benchmark/Cistern.Benchmarks.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Cistern.Linq" Version="0.1.1" />
     <PackageReference Include="LinqAF" Version="3.0.0" />
     <PackageReference Include="NetFabric.Hyperlinq" Version="3.0.0-beta26" />
-    <PackageReference Include="StructLinq.BCL" Version="0.20.2" />
+    <PackageReference Include="StructLinq.BCL" Version="0.20.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -25,7 +25,7 @@ namespace Cistern.Benchmarks
             ValueLambdas.WhereSelectSum.Benchmark.SanityCheck();
             ValueLambdas.SelectWhereMax.Benchmark.SanityCheck();
 
-            var summary = BenchmarkRunner.Run<ValueLambdas.SelectWhereMax.Benchmark> ();
+            var summary = BenchmarkRunner.Run<ValueLambdas.WhereSelect.Benchmark> ();
         }
     }
 }

--- a/Benchmark/ValueLambdas/SelectWhereMax/Benchmark.StructLinq.cs
+++ b/Benchmark/ValueLambdas/SelectWhereMax/Benchmark.StructLinq.cs
@@ -29,7 +29,7 @@ namespace Cistern.Benchmarks.ValueLambdas.SelectWhereMax
                     .ToStructEnumerable()
                     .Select(ref @select, x => x, x => x)
                     .Where(ref @where, x => x)
-                    .Max();
+                    .Max(x=>x);
             }
 
             static int AsArray(int[] array)
@@ -42,7 +42,7 @@ namespace Cistern.Benchmarks.ValueLambdas.SelectWhereMax
                     .ToStructEnumerable()
                     .Select(ref @select, x => x, x => x)
                     .Where(ref @where, x => x)
-                    .Max();
+                    .Max(x=>x);
             }
 
             static int AsEnumerable(IEnumerable<int> enumerable)
@@ -55,7 +55,7 @@ namespace Cistern.Benchmarks.ValueLambdas.SelectWhereMax
                     .ToStructEnumerable()
                     .Select(ref @select, x => x, x => x)
                     .Where(ref @where, x => x)
-                    .Max();
+                    .Max(x=>x);
             }
         }
     }

--- a/Benchmark/ValueLambdas/WhereSelect/Benchmark.CisternValueLinq.cs
+++ b/Benchmark/ValueLambdas/WhereSelect/Benchmark.CisternValueLinq.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+
+namespace Cistern.Benchmarks.ValueLambdas.WhereSelect
+{
+    partial class Benchmark
+    {
+        struct HalveAnInt : IFunc<int, int> { public int Invoke(int t) => t / 2; } 
+        struct FilterEvenInts : IFunc<int, bool> { public bool Invoke(int t) => (t & 1) == 0; }
+        
+        [Benchmark]
+        public int CisternValueLinq()
+        {
+            var enumerable = _ints
+                             .Where(new FilterEvenInts()) // ug, sugar please
+                             .Select(new HalveAnInt(), default(int)); // ug, sugar please + better type inference...
+            var sum = 0;
+            foreach (var i in enumerable)
+            {
+                sum += i;
+            }
+            return sum;
+        }
+    }
+}

--- a/Benchmark/ValueLambdas/WhereSelect/Benchmark.Handcoded.cs
+++ b/Benchmark/ValueLambdas/WhereSelect/Benchmark.Handcoded.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+
+namespace Cistern.Benchmarks.ValueLambdas.WhereSelect
+{
+    partial class Benchmark
+    {
+        [Benchmark(Baseline = true)]
+        public double Handcoded()
+        {
+            return _ints switch
+            {
+                int[] asArray    => AsArray(asArray),
+                List<int> asList => AsList(asList),
+                var x            => AsEnumerable(x)
+            };
+
+            static int AsList(List<int> asList)
+            {
+                var total = 0;
+                foreach (var x in asList)
+                {
+                    if ((x & 1) == 0)
+                        total += x * 2;
+                }
+
+                return total;
+            }
+
+            static int AsArray(int[] asArray)
+            {
+                var total = 0;
+                foreach (var x in asArray)
+                {
+                    if ((x & 1) == 0)
+                        total += x * 2;
+                }
+
+                return total;
+            }
+
+            static int AsEnumerable(IEnumerable<int> asArray)
+            {
+                var total = 0;
+                foreach (var x in asArray)
+                {
+                    if ((x & 1) == 0)
+                        total += x * 2;
+                }
+
+                return total;
+            }
+        }
+    }
+}

--- a/Benchmark/ValueLambdas/WhereSelect/Benchmark.StructLinq.cs
+++ b/Benchmark/ValueLambdas/WhereSelect/Benchmark.StructLinq.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using StructLinq;
+
+namespace Cistern.Benchmarks.ValueLambdas.WhereSelect
+{
+    partial class Benchmark
+    {
+        struct WherePredicate : IFunction<int, bool> { public bool Eval(int element) => (element & 1) == 0; }
+        struct SelectFunction : IFunction<int, int> { public int Eval(int element) => element / 2; }
+
+        [Benchmark]
+        public int StructLinq()
+        {
+            return _ints switch
+            {
+                int[] asArray => AsArray(asArray),
+                List<int> asList => AsList(asList),
+                var x => AsEnumerable(x)
+            };
+
+            static int AsList(List<int> list)
+            {
+                var where = new WherePredicate();
+                var select = new SelectFunction();
+
+                var enumerable = list
+                                      .ToStructEnumerable()
+                                      .Where(ref @where, x => x)
+                                      .Select(ref @select, x => x, x => x);
+                var sum = 0;
+                foreach (var i in enumerable)
+                {
+                    sum += i;
+                }
+                return sum;
+            }
+
+            static int AsArray(int[] array)
+            {
+                var where = new WherePredicate();
+                var select = new SelectFunction();
+
+                var enumerable = array
+                                 .ToStructEnumerable()
+                                 .Where(ref @where, x => x)
+                                 .Select(ref @select, x => x, x => x);
+                var sum = 0;
+                foreach (var i in enumerable)
+                {
+                    sum += i;
+                }
+                return sum;
+            }
+
+            static int AsEnumerable(IEnumerable<int> enumerable)
+            {
+                var where = new WherePredicate();
+                var select = new SelectFunction();
+
+                var structEnum = enumerable
+                                 .ToStructEnumerable()
+                                 .Where(ref @where, x => x)
+                                 .Select(ref @select, x => x, x => x);
+                var sum = 0;
+                foreach (var i in structEnum)
+                {
+                    sum += i;
+                }
+                return sum;
+            }
+        }
+    }
+}

--- a/Benchmark/ValueLambdas/WhereSelect/Benchmark.cs
+++ b/Benchmark/ValueLambdas/WhereSelect/Benchmark.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace Cistern.Benchmarks.ValueLambdas.WhereSelect
+{
+    [MemoryDiagnoser]
+    public partial class Benchmark
+    {
+        IEnumerable<int> _ints;
+
+#if trueX
+        [Params(0, 1, 10, 100, 1000, 1000000)]
+#else
+        [Params(1, 100, 1000000)]
+#endif
+        public int Length { get; set; } = 0;
+
+#if trueX
+        [Params(ContainerTypes.Array, ContainerTypes.Enumerable, ContainerTypes.List)]
+#else
+        [Params(ContainerTypes.Array)]
+#endif
+        public ContainerTypes ContainerType { get; set; } = ContainerTypes.Enumerable;
+
+        [GlobalSetup]
+        public void SetupData()
+        {
+            var data = Create(Length);
+
+            _ints = ContainerType switch
+            {
+                ContainerTypes.Enumerable => data,
+                ContainerTypes.Array => data.ToArray(),
+                ContainerTypes.List => data.ToList(),
+
+                _ => throw new Exception("Unknown ContainerType")
+            };
+        }
+
+        private static IEnumerable<int> Create(int size)
+        {
+            for (var i = 0; i < size; ++i)
+                yield return i % 1000;
+        }
+
+        internal static void SanityCheck()
+        {
+            var check = new Benchmark();
+
+            check.Length = 100;
+            check.ContainerType = ContainerTypes.Array;
+            check.SetupData();
+
+            var baseline = check.Handcoded();
+
+            var cisternvaluelinq = check.CisternValueLinq();
+            if (baseline != cisternvaluelinq) throw new Exception();
+
+#if STRUCTLINQ
+            var structlinq = check.StructLinq();
+            if (structlinq != baseline) throw new Exception();
+#endif
+        }
+    }
+}

--- a/Benchmark/ValueLambdas/WhereSelectSum/Benchmark.StructLinq.cs
+++ b/Benchmark/ValueLambdas/WhereSelectSum/Benchmark.StructLinq.cs
@@ -29,7 +29,7 @@ namespace Cistern.Benchmarks.ValueLambdas.WhereSelectSum
                     .ToStructEnumerable()
                     .Where(ref @where, x => x)
                     .Select(ref @select, x => x, x => x)
-                    .Sum();
+                    .Sum(x=>x);
             }
 
             static int AsArray(int[] array)
@@ -42,7 +42,7 @@ namespace Cistern.Benchmarks.ValueLambdas.WhereSelectSum
                     .ToStructEnumerable()
                     .Where(ref @where, x => x)
                     .Select(ref @select, x => x, x => x)
-                    .Sum();
+                    .Sum(x=>x);
             }
 
             static int AsEnumerable(IEnumerable<int> enumerable)
@@ -55,7 +55,7 @@ namespace Cistern.Benchmarks.ValueLambdas.WhereSelectSum
                     .ToStructEnumerable()
                     .Where(ref @where, x => x)
                     .Select(ref @select, x => x, x => x)
-                    .Sum();
+                    .Sum(x=>x);
             }
         }
     }


### PR DESCRIPTION
Hi,

I have a look to your code. 

I like your concept of `IForwardEnumerator` ! (maybe I can implement it in StructLinq).

I add a bench just on a foreach.

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.403
  [Host]     : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  DefaultJob : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT


```
|           Method |  Length | ContainerType |             Mean |          Error |         StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |-------- |-------------- |-----------------:|---------------:|---------------:|------:|--------:|-------:|------:|------:|----------:|
| **CisternValueLinq** |       **1** |         **Array** |       **161.815 ns** |      **3.2386 ns** |      **3.3258 ns** | **26.81** |    **0.85** | **0.0114** |     **-** |     **-** |      **48 B** |
|        Handcoded |       1 |         Array |         6.040 ns |      0.1294 ns |      0.1147 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|       StructLinq |       1 |         Array |        57.396 ns |      0.3768 ns |      0.3340 ns |  9.51 |    0.18 |      - |     - |     - |         - |
|                  |         |               |                  |                |                |       |         |        |       |       |           |
| **CisternValueLinq** |     **100** |         **Array** |       **456.974 ns** |      **7.4469 ns** |      **6.6015 ns** |  **5.09** |    **0.08** | **0.0114** |     **-** |     **-** |      **48 B** |
|        Handcoded |     100 |         Array |        89.760 ns |      0.6288 ns |      0.5574 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|       StructLinq |     100 |         Array |       223.420 ns |      1.2679 ns |      1.0587 ns |  2.49 |    0.02 |      - |     - |     - |         - |
|                  |         |               |                  |                |                |       |         |        |       |       |           |
| **CisternValueLinq** | **1000000** |         **Array** | **2,894,997.721 ns** | **15,447.6889 ns** | **12,060.5394 ns** |  **4.52** |    **0.08** |      **-** |     **-** |     **-** |      **50 B** |
|        Handcoded | 1000000 |         Array |   640,500.781 ns | 10,916.5129 ns |  9,677.2043 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|       StructLinq | 1000000 |         Array | 1,605,377.107 ns | 22,961.5417 ns | 20,354.8087 ns |  2.51 |    0.05 |      - |     - |     - |       3 B |

I think you should have a specific path to create `Enumerator<T>` without allocation.

I also think that `IFastEnumerator<T>` is slower that `IEnumerator<T>`. This bench proves it because StructLinq "implements" `IEnumerator<T>`

Regards.